### PR TITLE
Fabioduque feature/add categories to selected days

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ npm install vue-material-year-calendar --save
     :activeDates.sync ="activeDates"
     @toggleDate="toggleDate"
     lang="tw"
+    :showYearSelector="showYearSelector"
   ></YearCalendar>
 </template>
 
@@ -48,7 +49,8 @@ export default {
   data () {
     return {
       year: 2019,
-      activeDates: ['2018-01-01', '2019-01-01', '2019-01-02', '2019-01-03', '2020-01-01']
+      activeDates: ['2018-01-01', '2019-01-01', '2019-01-02', '2019-01-03', '2020-01-01'],
+      showYearSelector: true
     }
   },
   methods: {
@@ -90,6 +92,16 @@ Choose language to displayed.
 
 `en`: English, `tw`: 繁體中文
 
+### showYearSelector 
+   * Type: `Boolean`
+   * Default: true
+
+Show or hide the years selector on top of the calendar.
+
+ex: 
+```javascript
+:showYearSelector="false"
+```
 
 ## 📚 event
 ### @toggleDate

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 English | [繁體中文](./doc/tw.md)
-# Vue Material Year Calendar
+![](https://i.imgur.com/0JRDuTV.png)
 <p align="center">
 <a href="https://www.npmjs.com/package/vue-material-year-calendar"><img src="https://img.shields.io/npm/v/vue-material-year-calendar.svg"  alt="Versions"></a> <a  href="https://www.npmjs.com/package/vue-material-year-calendar"><img  src="https://img.shields.io/npm/dm/vue-material-year-calendar.svg"  alt="Downloads"></a> <a  href="https://www.npmjs.com/package/vue-material-year-calendar"><img src="https://img.shields.io/npm/l/vue-material-year-calendar.svg"  alt="License"></a>
 </p>  

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 English | [繁體中文](./doc/tw.md)
-![](https://i.imgur.com/0JRDuTV.png)
+![](https://i.imgur.com/7rinsub.png)
+<!-- ![](https://i.imgur.com/0JRDuTV.png) -->
 <p align="center">
 <a href="https://www.npmjs.com/package/vue-material-year-calendar"><img src="https://img.shields.io/npm/v/vue-material-year-calendar.svg"  alt="Versions"></a> <a  href="https://www.npmjs.com/package/vue-material-year-calendar"><img  src="https://img.shields.io/npm/dm/vue-material-year-calendar.svg"  alt="Downloads"></a> <a  href="https://www.npmjs.com/package/vue-material-year-calendar"><img src="https://img.shields.io/npm/l/vue-material-year-calendar.svg"  alt="License"></a>
 </p>  
@@ -90,11 +91,11 @@ ex:
 
 Choose language to displayed.
 
-`en`: English, `tw`: 繁體中文
+`en`: English, `tw`: 繁體中文, `pt`: Português
 
 ### showYearSelector 
    * Type: `Boolean`
-   * Default: true
+   * Default: `true`
 
 Show or hide the years selector on top of the calendar.
 

--- a/doc/tw.md
+++ b/doc/tw.md
@@ -38,6 +38,7 @@ npm install vue-material-year-calendar --save
     :activeDates.sync ="activeDates"
     @toggleDate="toggleDate"
     lang="tw"
+    :showYearSelector="showYearSelector"
   ></YearCalendar>
 </template>
 
@@ -49,7 +50,8 @@ export default {
   data () {
     return {
       year: 2019,
-      activeDates: ['2018-01-01', '2019-01-01', '2019-01-02', '2019-01-03', '2020-01-01']
+      activeDates: ['2018-01-01', '2019-01-01', '2019-01-02', '2019-01-03', '2020-01-01'],
+      showYearSelector: true
     }
   },
   methods: {
@@ -91,6 +93,16 @@ ex:
 
 `en`: English, `tw`: 繁體中文。 Taiwan NO.1
 
+### showYearSelector 
+   * Type: `Boolean`
+   * Default: true
+
+是否顯示選擇年份的 Bar
+
+ex: 
+```javascript
+:showYearSelector="false"
+```
 
 ## 📚 事件
 ### @toggleDate

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-material-year-calendar",
   "main": "index.js",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-material-year-calendar",
   "main": "index.js",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,7 @@ export default {
     return {
       lang: 'tw',
       year: 2019,
-      activeDates: ['2019-03-13', '2019-12-31']
+      activeDates: ['2019-03-13', '2019-12-31', '2019-99-99']
     }
   },
   methods: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -45,7 +45,7 @@ export default {
       year: 2019,
       activeDates: [{ date: '2019-03-13', className: 'red' }, { date: '2019-03-14', className: 'blue' }],
       // activeDates: ['2019-03-12', '2019-03-16'],
-      defaultClassName: ''
+      defaultClassName: '',
       showYearSelector: true
     }
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,6 +26,7 @@
       :lang="lang"
       :defaultClassName="defaultClassName"
       :showYearSelector="showYearSelector"
+      :colorful="colorful"
     ></year-calendar>
   </div>
 </template>
@@ -41,6 +42,7 @@ export default {
   },
   data () {
     return {
+      colorful: true,
       lang: 'en', // 'en', 'tw', 'pt'
       year: 2019,
       activeDates: [{ date: '2019-03-13', className: 'red' }, { date: '2019-03-14', className: 'blue' }],

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,8 +6,13 @@
       <option value="tw">繁體中文</option>
       <option value="en">English</option>
     </select>
+    <label for="">
+      Show years selector?
+      <input type="checkbox" v-model="showYearSelector" >
+    </label>
     <year-calendar
       v-model="year"
+      :showYearSelector="showYearSelector"
       :activeDates.sync="activeDates"
       @toggleDate="toggleDate"
       :lang="lang"
@@ -28,6 +33,7 @@ export default {
     return {
       lang: 'en', // 'en' or 'tw'
       year: 2019,
+      showYearSelector: true,
       activeDates: ['2019-03-13', '2019-12-31']
     }
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,8 +26,8 @@
       :lang="lang"
       :defaultClassName="defaultClassName"
       :showYearSelector="showYearSelector"
-      :colorful="colorful"
-      activeClass="custom-day-active-class"
+      colorful
+      dayActiveClass="custom-day-active-class"
     ></year-calendar>
   </div>
 </template>
@@ -43,14 +43,10 @@ export default {
   },
   data () {
     return {
-      colorful: true,
       lang: 'en', // 'en', 'tw', 'pt'
       year: 2019,
       activeDates: [{ date: '2019-03-13', className: 'red' }, { date: '2019-03-14', className: 'blue' }],
-<<<<<<< HEAD
-=======
       // activeDates: ['2019-03-12', '2019-03-16'],
->>>>>>> 01bfa148828e708875a645c10f1b7d238aec3204
       defaultClassName: '',
       showYearSelector: true
     }
@@ -65,6 +61,7 @@ export default {
       while (theDate.diff(theDate.endOf('year'), 'day') !== 0) {
         if (theDate.day() === 6 || theDate.day() === 0) {
           // 將週六或週日加入 activeDates 中
+          // add weekend to activeDates
           this.activeDates.push(theDate.format('YYYY-MM-DD'))
         }
         theDate = theDate.add(1, 'day')
@@ -94,14 +91,16 @@ export default {
 #app
   padding 60px
   background-color #eaeaea
-
 .custom-day-active-class
   background-color: #0aa
-  color: white !important
+  color: white
   &.blue
     background-color: #0000aa
-    color: white !important
+    color: white
+    &:after
+      background-image url('./assets/baseline-remove_circle-24px.svg')
+      background-size 100% 100%
   &.red
     background-color: #a00
-    color: white !important
+    color: white
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -44,8 +44,7 @@ export default {
       lang: 'en', // 'en', 'tw', 'pt'
       year: 2019,
       activeDates: [{ date: '2019-03-13', className: 'red' }, { date: '2019-03-14', className: 'blue' }],
-      // activeDates: ['2019-03-12', '2019-03-16'],
-      defaultClassName: ''
+      defaultClassName: '',
       showYearSelector: true
     }
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,11 +6,19 @@
       <option value="tw">繁體中文</option>
       <option value="en">English</option>
     </select>
+
+    <select v-model="defaultClassName">
+      <option selected value="">(none)</option>
+      <option value="red">red</option>
+      <option value="blue">blue</option>
+    </select>
+
     <year-calendar
       v-model="year"
       :activeDates.sync="activeDates"
       @toggleDate="toggleDate"
       :lang="lang"
+      :defaultClassName="defaultClassName"
     ></year-calendar>
   </div>
 </template>
@@ -28,7 +36,9 @@ export default {
     return {
       lang: 'en', // 'en' or 'tw'
       year: 2019,
-      activeDates: ['2019-03-13', '2019-12-31']
+      activeDates: [{ date: '2019-03-13', className: 'red' }, { date: '2019-03-14', className: 'blue' }],
+      // activeDates: ['2019-03-12', '2019-03-16'],
+      defaultClassName: ''
     }
   },
   methods: {
@@ -70,4 +80,12 @@ export default {
 #app
   padding 60px
   background-color #eaeaea
+
+.day.calendar--active
+  &.blue
+    background-color: #00a !important
+    color: white !important
+  &.red
+    background-color: #a00 !important
+    color: white !important
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
     <select v-model="lang">
       <option value="tw">繁體中文</option>
       <option value="en">English</option>
+      <option value="pt">Português</option>
     </select>
     <year-calendar
       v-model="year"
@@ -26,7 +27,7 @@ export default {
   },
   data () {
     return {
-      lang: 'en', // 'en' or 'tw'
+      lang: 'en', // 'en', 'tw', 'pt'
       year: 2019,
       activeDates: ['2019-03-13', '2019-12-31']
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,7 +26,6 @@
       :lang="lang"
       :defaultClassName="defaultClassName"
       :showYearSelector="showYearSelector"
-      colorful
       dayActiveClass="custom-day-active-class"
     ></year-calendar>
   </div>
@@ -45,8 +44,8 @@ export default {
     return {
       lang: 'en', // 'en', 'tw', 'pt'
       year: 2019,
-      activeDates: [{ date: '2019-03-13', className: 'red' }, { date: '2019-03-14', className: 'blue' }],
-      // activeDates: ['2019-03-12', '2019-03-16'],
+      // activeDates: [{ date: '2019-03-13', className: 'red' }, { date: '2019-03-14', className: 'blue' }],
+      activeDates: ['2019-03-12', '2019-03-16'],
       defaultClassName: '',
       showYearSelector: true
     }
@@ -97,10 +96,10 @@ export default {
   &.blue
     background-color: #0000aa
     color: white
-    &:after
-      background-image url('./assets/baseline-remove_circle-24px.svg')
-      background-size 100% 100%
   &.red
     background-color: #a00
     color: white
+    &:after
+      background-image url('./assets/baseline-remove_circle-24px.svg')
+      background-size 100% 100%
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -27,6 +27,7 @@
       :defaultClassName="defaultClassName"
       :showYearSelector="showYearSelector"
       :colorful="colorful"
+      activeClass="custom-day-active-class"
     ></year-calendar>
   </div>
 </template>
@@ -91,11 +92,13 @@ export default {
   padding 60px
   background-color #eaeaea
 
-.day.calendar--active
+.custom-day-active-class
+  background-color: #0aa
+  color: white !important
   &.blue
-    background-color: #00a !important
+    background-color: #0000aa
     color: white !important
   &.red
-    background-color: #a00 !important
+    background-color: #a00
     color: white !important
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,10 +12,10 @@
     </label>
     <year-calendar
       v-model="year"
-      :showYearSelector="showYearSelector"
       :activeDates.sync="activeDates"
       @toggleDate="toggleDate"
       :lang="lang"
+      :showYearSelector="showYearSelector"
     ></year-calendar>
   </div>
 </template>
@@ -33,8 +33,8 @@ export default {
     return {
       lang: 'en', // 'en' or 'tw'
       year: 2019,
-      showYearSelector: true,
-      activeDates: ['2019-03-13', '2019-12-31']
+      activeDates: ['2019-03-13', '2019-12-31'],
+      showYearSelector: true
     }
   },
   methods: {

--- a/src/components/MonthCalendar.vue
+++ b/src/components/MonthCalendar.vue
@@ -57,14 +57,16 @@ export default {
     weekTitleFontSizeAdjustLang () {
       const fontSizeMapping = {
         tw: '16px',
-        en: '14px'
+        en: '14px',
+        pt: '14px'
       }
       return fontSizeMapping[this.lang]
     },
     monthTitle () {
       const monthMapping = {
         tw: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'],
-        en: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+        en: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+        pt: ['Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro']
       }
       return monthMapping[this.lang][this.month - 1]
     }
@@ -108,7 +110,8 @@ export default {
     showDayTitle (day) {
       const dayMapping = {
         tw: ['一', '二', '三', '四', '五', '六', '日'],
-        en: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
+        en: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
+        pt: ['Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb', 'Dom']
       }
       return dayMapping[this.lang][day]
     },

--- a/src/components/MonthCalendar.vue
+++ b/src/components/MonthCalendar.vue
@@ -143,6 +143,16 @@ export default {
     },
     mouseUp () {
       this.isMouseDown = false
+    },
+    classList (dayObj) {
+      let oClassList = {
+        'calendar__day--otherMonth': dayObj.isOtherMonth,
+        'calendar--active': dayObj.active
+      }
+
+      if (dayObj.active) oClassList[dayObj.className] = true
+
+      return oClassList
     }
   },
   watch: {

--- a/src/components/MonthCalendar.vue
+++ b/src/components/MonthCalendar.vue
@@ -43,6 +43,10 @@ export default {
     defaultClassName: {
       type: String,
       default: () => ''
+    },
+    activeClass: {
+      type: String,
+      default: () => 'calendar--active'
     }
   },
   data () {
@@ -147,7 +151,7 @@ export default {
     classList (dayObj) {
       let oClassList = {
         'calendar__day--otherMonth': dayObj.isOtherMonth,
-        'calendar--active': dayObj.active
+        [this.activeClass]: dayObj.active
       }
 
       if (dayObj.active) oClassList[dayObj.className] = true
@@ -226,6 +230,7 @@ export default {
     justify-content center
     align-items center
     position relative
+    border-radius 5px
     &:after
       content ''
       display block
@@ -246,7 +251,6 @@ export default {
     &.calendar--active
       background-color: rgba(#FFBABA, .5)
       color #BCBCBC
-      border-radius 5px
   & .calendar__day--otherMonth
     color: #eaeaea
     cursor: auto

--- a/src/components/MonthCalendar.vue
+++ b/src/components/MonthCalendar.vue
@@ -16,9 +16,7 @@
             'calendar__day--otherMonth': dayObj.isOtherMonth,
             'calendar--active': dayObj.active
           }"
-        >
-          {{ dayObj.value }}
-        </div>
+        >{{ dayObj.value }}</div>
       </div>
     </div>
   </div>

--- a/src/components/MonthCalendar.vue
+++ b/src/components/MonthCalendar.vue
@@ -12,10 +12,7 @@
           @mouseover="dragDay(dayObj)"
           @mousedown="mouseDown(dayObj)"
           class="day"
-          :class="{
-            'calendar__day--otherMonth': dayObj.isOtherMonth,
-            'calendar--active': dayObj.active
-          }"
+          :class="classList(dayObj)"
         >
           {{ dayObj.value }}
         </div>
@@ -45,6 +42,10 @@ export default {
     lang: {
       type: String,
       default: 'en'
+    },
+    defaultClassName: {
+      type: String,
+      default: () => ''
     }
   },
   data () {
@@ -97,13 +98,25 @@ export default {
 
       // 把 toggleDate 的內容合併在 initCalendar 裡。
       this.activeDates.forEach(date => {
-        let dayjsObj = dayjs(date)
-        if (dayjsObj.year() !== this.year) return
-        let activeDate = dayjsObj.date()
-        let row = Math.floor(activeDate / 7)
-        let activeArrayKey = (activeDate % 7 - 1 + firstDay) + 7 * row
-        this.showDays[activeArrayKey].active = true // to array index
-      })
+        let oDate;
+
+        if (typeof date === "string") {
+            oDate = {
+                date: date,
+                className: this.defaultClassName
+            };
+        } else if (typeof date === "object") {
+            oDate = date;
+        }
+
+        let dayjsObj = dayjs(oDate.date);
+        if (dayjsObj.year() !== this.year) return;
+        let activeDate = dayjsObj.date();
+        let row = Math.floor(activeDate / 7);
+        let activeArrayKey = (activeDate % 7) - 1 + firstDay + 7 * row;
+        this.showDays[activeArrayKey].active = true; // to array index
+        this.showDays[activeArrayKey].className = oDate.className;
+      });
     },
     showDayTitle (day) {
       const dayMapping = {
@@ -117,7 +130,8 @@ export default {
       this.$emit('toggleDate', {
         month: this.month,
         date: dayObj.value,
-        selected: !dayObj.active
+        selected: !dayObj.active,
+        className: dayObj.className || this.defaultClassName
       })
     },
     dragDay (dayObj) {

--- a/src/components/MonthCalendar.vue
+++ b/src/components/MonthCalendar.vue
@@ -98,25 +98,25 @@ export default {
 
       // 把 toggleDate 的內容合併在 initCalendar 裡。
       this.activeDates.forEach(date => {
-        let oDate;
+        let oDate
 
-        if (typeof date === "string") {
-            oDate = {
-                date: date,
-                className: this.defaultClassName
-            };
-        } else if (typeof date === "object") {
-            oDate = date;
+        if (typeof date === 'string') {
+          oDate = {
+            date: date,
+            className: this.defaultClassName
+          }
+        } else if (typeof date === 'object') {
+          oDate = date
         }
 
-        let dayjsObj = dayjs(oDate.date);
-        if (dayjsObj.year() !== this.year) return;
-        let activeDate = dayjsObj.date();
-        let row = Math.floor(activeDate / 7);
-        let activeArrayKey = (activeDate % 7) - 1 + firstDay + 7 * row;
-        this.showDays[activeArrayKey].active = true; // to array index
-        this.showDays[activeArrayKey].className = oDate.className;
-      });
+        let dayjsObj = dayjs(oDate.date)
+        if (dayjsObj.year() !== this.year) return
+        let activeDate = dayjsObj.date()
+        let row = Math.floor(activeDate / 7)
+        let activeArrayKey = (activeDate % 7) - 1 + firstDay + 7 * row
+        this.showDays[activeArrayKey].active = true // to array index
+        this.showDays[activeArrayKey].className = oDate.className
+      })
     },
     showDayTitle (day) {
       const dayMapping = {

--- a/src/components/MonthCalendar.vue
+++ b/src/components/MonthCalendar.vue
@@ -111,7 +111,7 @@ export default {
       const dayMapping = {
         tw: ['一', '二', '三', '四', '五', '六', '日'],
         en: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
-        pt: ['Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb', 'Dom']
+        pt: ['2ª', '3ª', '4ª', '5ª', '6ª', 'Sa', 'Do']
       }
       return dayMapping[this.lang][day]
     },

--- a/src/components/MonthCalendar.vue
+++ b/src/components/MonthCalendar.vue
@@ -44,7 +44,7 @@ export default {
       type: String,
       default: () => ''
     },
-    activeClass: {
+    dayActiveClass: {
       type: String,
       default: () => 'calendar--active'
     }
@@ -151,7 +151,7 @@ export default {
     classList (dayObj) {
       let oClassList = {
         'calendar__day--otherMonth': dayObj.isOtherMonth,
-        [this.activeClass]: dayObj.active
+        [this.dayActiveClass]: dayObj.active
       }
 
       if (dayObj.active) oClassList[dayObj.className] = true
@@ -218,14 +218,16 @@ export default {
     justify-content center
     align-items center
     font-size 16px
-    height: 31px
+    height 31px
+    color #5DB3D4
+  .day__weektitle
+    color rgba(#353C46, .8)
   .day
     font-size 14px
     cursor pointer
     user-select none
     width: 22px
     height 22px
-    color: #5DB3D4
     display flex
     justify-content center
     align-items center

--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -175,7 +175,8 @@ export default {
     }
   },
   created () {
-    this.isUsingString = typeof this.activeDates[0] === 'string'
+    this.isUsingString = this.activeDates.length && typeof this.activeDates[0] === 'string'
+    console.log(this.isUsingString)
   }
 }
 </script>

--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -23,6 +23,7 @@
         :defaultClassName="defaultClassName"
         @toggleDate="toggleDate"
         :lang="lang"
+        :activeClass="activeClass"
       >
       </month-calendar>
     </div>
@@ -87,6 +88,10 @@ export default {
       default: 'en'
     },
     defaultClassName: {
+      type: String,
+      default: () => ''
+    },
+    activeClass: {
       type: String,
       default: () => ''
     }

--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -36,10 +36,6 @@ import MonthCalendar from './MonthCalendar'
 export default {
   name: 'year-calendar',
   props: {
-    colorful: {
-      type: Boolean,
-      default: () => false
-    },
     showYearSelector: {
       type: Boolean,
       default: () => true
@@ -96,6 +92,11 @@ export default {
       default: () => ''
     }
   },
+  data () {
+    return {
+      isUsingString: true
+    }
+  },
   components: {
     MonthCalendar
   },
@@ -149,7 +150,7 @@ export default {
       let dateIndex
       let newDates
 
-      if (!this.colorful) {
+      if (this.isUsingString) {
         dateIndex = this.activeDates.indexOf(activeDate)
         newDates = this.modifiedActiveDates(dateIndex, activeDate)
       } else {
@@ -172,6 +173,9 @@ export default {
       }
       return newDates
     }
+  },
+  created () {
+    this.isUsingString = typeof this.activeDates[0] === 'string'
   }
 }
 </script>

--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -35,6 +35,10 @@ import MonthCalendar from './MonthCalendar'
 export default {
   name: 'year-calendar',
   props: {
+    colorful: {
+      type: Boolean,
+      default: () => false
+    },
     showYearSelector: {
       type: Boolean,
       default: () => true
@@ -137,33 +141,31 @@ export default {
         className: dateObj.className
       })
 
-      let newDates = [...this.activeDates]
+      let dateIndex
+      let newDates
 
-      if (this.activeDates.length && typeof this.activeDates[0] === 'string') {
-        let dateIndex = newDates.indexOf(activeDate)
-        if (dateIndex === -1) {
-          newDates.push(activeDate)
-        } else {
-          newDates.splice(dateIndex, 1)
-        }
+      if (!this.colorful) {
+        dateIndex = this.activeDates.indexOf(activeDate)
+        newDates = this.modifiedActiveDates(dateIndex, activeDate)
       } else {
         let oDate = {
           date: activeDate,
           className: this.defaultClassName
         }
 
-        let dateIndex = newDates.indexOf(newDates.find((i) => {
-          return i.date === activeDate
-        }))
-
-        if (dateIndex === -1) {
-          newDates.push(oDate)
-        } else {
-          newDates.splice(dateIndex, 1)
-        }
+        dateIndex = this.activeDates.indexOf(this.activeDates.find((i) => i.date === activeDate))
+        newDates = this.modifiedActiveDates(dateIndex, oDate)
       }
-
       this.$emit('update:activeDates', newDates)
+    },
+    modifiedActiveDates (dateIndex, activeDate) {
+      let newDates = [...this.activeDates]
+      if (dateIndex === -1) {
+        newDates.push(activeDate)
+      } else {
+        newDates.splice(dateIndex, 1)
+      }
+      return newDates
     }
   }
 }

--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="vue-calendar__container">
-    <div class="container__year">
+    <div v-if="showYearSelector" class="container__year">
       <!-- <span><button @click="addYear(-1)">back</button></span> -->
       <span
         v-for="i in 5"
@@ -34,6 +34,10 @@ import MonthCalendar from './MonthCalendar'
 export default {
   name: 'year-calendar',
   props: {
+    showYearSelector: {
+      type: Boolean,
+      default: () => true
+    },
     activeDates: {
       type: Array,
       default: () => [],

--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -23,7 +23,7 @@
         :defaultClassName="defaultClassName"
         @toggleDate="toggleDate"
         :lang="lang"
-        :activeClass="activeClass"
+        :dayActiveClass="dayActiveClass"
       >
       </month-calendar>
     </div>
@@ -91,7 +91,7 @@ export default {
       type: String,
       default: () => ''
     },
-    activeClass: {
+    dayActiveClass: {
       type: String,
       default: () => ''
     }

--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -47,18 +47,17 @@ export default {
             isGood = false
           }
           // Parse the date parts to integers
-          var parts = date.split('-')
-          var day = parseInt(parts[2], 10)
-          var month = parseInt(parts[1], 10)
-          var year = parseInt(parts[0], 10)
+          let parts = date.split('-')
+          let day = parseInt(parts[2], 10)
+          let month = parseInt(parts[1], 10)
+          let year = parseInt(parts[0], 10)
 
-          if (year < 1000 || year > 3000 || month === 0 || month > 12) { return false }
-          var monthLength = [ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ]
-          if (year % 400 === 0 || (year % 100 !== 0 && year % 4 === 0)) { monthLength[1] = 29 }
-          if (day > 0 && day <= monthLength[month - 1]) isGood = true
-          else isGood = false
+          if (year < 1000 || year > 3000 || month === 0 || month > 12) isGood = false
+          let monthLength = [ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ]
+          if (year % 400 === 0 || (year % 100 !== 0 && year % 4 === 0)) monthLength[1] = 29
+          if (!(day > 0 && day <= monthLength[month - 1])) isGood = false
         })
-        if (isGood) { return true } else return false
+        return isGood
       }
     },
     // value 為從外層傳進來的 v-model="year"

--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -20,6 +20,7 @@
         :year="activeYear"
         :month="n"
         :activeDates="month[n]"
+        :defaultClassName="defaultClassName"
         @toggleDate="toggleDate"
         :lang="lang"
       >
@@ -39,15 +40,23 @@ export default {
       default: () => [],
       validator: (dateArray) => {
         let isGood = true
+        let curDate = null
+
         dateArray.forEach(date => {
+          if (typeof date === 'string') {
+            curDate = date
+          } else if (typeof date === 'object' && date.hasOwnProperty('date')) {
+            curDate = date.date
+          }
+
           // 以下程式碼參考「How to validate date with format mm/dd/yyyy in JavaScript?」in Stackoverflow
           // 由於 「^\d{4}\-\d{1,2}\-\d{1,2}$」會被ESLint 判為錯誤，所以暫時關閉 EsLint 對下一行的驗證 by丁丁
           // eslint-disable-next-line no-useless-escape
-          if (!/^\d{4}\-\d{1,2}\-\d{1,2}$/.test(date)) {
+          if (!/^\d{4}\-\d{1,2}\-\d{1,2}$/.test(curDate)) {
             isGood = false
           }
           // Parse the date parts to integers
-          var parts = date.split('-')
+          var parts = curDate.split('-')
           var day = parseInt(parts[2], 10)
           var month = parseInt(parts[1], 10)
           var year = parseInt(parts[0], 10)
@@ -58,7 +67,7 @@ export default {
           if (day > 0 && day <= monthLength[month - 1]) isGood = true
           else isGood = false
         })
-        if (isGood) { return true } else return false
+        return isGood
       }
     },
     // value 為從外層傳進來的 v-model="year"
@@ -69,6 +78,10 @@ export default {
     lang: {
       type: String,
       default: 'en'
+    },
+    defaultClassName: {
+      type: String,
+      default: () => ''
     }
   },
   components: {
@@ -78,10 +91,21 @@ export default {
     month () {
       const month = {}
       this.activeDates.forEach(date => {
-        if (dayjs(date).year() !== this.value) return // 讓2020年1月的資料，不會放到 2019年的1月資料裡
-        let m = (dayjs(date).month() + 1).toString()
+        let oDate
+
+        if (typeof date === 'string') {
+          oDate = {
+            date: date,
+            className: this.defaultClassName
+          }
+        } else {
+          oDate = date
+        }
+
+        if (dayjs(oDate.date).year() !== this.value) return // 讓2020年1月的資料，不會放到 2019年的1月資料裡
+        let m = (dayjs(oDate.date).month() + 1).toString()
         if (!month[m]) month[m] = []
-        month[m].push(date)
+        month[m].push(oDate)
       })
       return month
     },
@@ -106,14 +130,34 @@ export default {
         .format('YYYY-MM-DD')
       this.$emit('toggleDate', {
         date: activeDate,
-        selected: dateObj.selected
+        selected: dateObj.selected,
+        className: dateObj.className
       })
+
       let newDates = [...this.activeDates]
-      let dateIndex = newDates.indexOf(activeDate)
-      if (dateIndex === -1) {
-        newDates.push(activeDate)
+
+      if (this.activeDates.length && typeof this.activeDates[0] === 'string') {
+        let dateIndex = newDates.indexOf(activeDate)
+        if (dateIndex === -1) {
+          newDates.push(activeDate)
+        } else {
+          newDates.splice(dateIndex, 1)
+        }
       } else {
-        newDates.splice(dateIndex, 1)
+        let oDate = {
+          date: activeDate,
+          className: this.defaultClassName
+        }
+
+        let dateIndex = newDates.indexOf(newDates.find((i) => {
+          return i.date === activeDate
+        }))
+
+        if (dateIndex === -1) {
+          newDates.push(oDate)
+        } else {
+          newDates.splice(dateIndex, 1)
+        }
       }
 
       this.$emit('update:activeDates', newDates)

--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -176,7 +176,6 @@ export default {
   },
   created () {
     this.isUsingString = this.activeDates.length && typeof this.activeDates[0] === 'string'
-    console.log(this.isUsingString)
   }
 }
 </script>


### PR DESCRIPTION
I add two props for `YearCalendar` component.

### colorful (Just for `YearCalendar`)
* Boolean
* default false

When `colorful=true` activeDates will sync by array with Object. `[{ date: '2019-03-13', className: 'red' }, { date: '2019-03-14', className: 'blue' }]`

`colorful=true` with String. `['2019-01-01', '2019-02-01']`

### activeClass (send to `MonthCalendar`)
* String
* default 'calendar--active'
Use on <year-calendar>
```html
    <year-calendar
      v-model="year"
      :activeDates.sync="activeDates"
      ...
      activeClass="custom-day-active-class"
    ></year-calendar>
```
Then user can use there custom classList.
```css
.custom-day-active-class
  background-color: #0aa
  color: white !important
  &.blue
    background-color: #0000aa
    color: white !important
  &.red
    background-color: #a00
    color: white !important
```

Do you have any other ideas?